### PR TITLE
icebug: downgrade to 12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "real-ladybug>=0.15.2",
     "fastembed",
-    "icebug>=12.2",
+    "icebug==12.2",
     "polars>=1.38.1",
     "dotenv>=0.9.9",
     "litellm>=1.81.15",


### PR DESCRIPTION
12.3 seems to have CI problems with libomp.dylib